### PR TITLE
[[ Bug 12778 ]]  Double clicking in the script editor doesn't highlight ...

### DIFF
--- a/docs/notes/bugfix-12778.md
+++ b/docs/notes/bugfix-12778.md
@@ -1,0 +1,1 @@
+#  Double clicking in the script editor doesn't highlight words

--- a/engine/src/lnxdclnx.cpp
+++ b/engine/src/lnxdclnx.cpp
@@ -644,7 +644,7 @@ Boolean MCScreenDC::handle(Boolean dispatch, Boolean anyevent, Boolean& abort, B
                                     {
                                         // This is a double-click event
                                         doubleclick = True;
-                                        MCdispatcher->wmdown(t_event->button.window, t_event->button.button);
+                                        MCdispatcher->wdoubledown(t_event->button.window, t_event->button.button);
                                     }
                                     
                                     reset = True;


### PR DESCRIPTION
...words
