### PR TITLE
Add Windows batch file for Visual Studio builds

### DIFF
--- a/make.cmd
+++ b/make.cmd
@@ -1,0 +1,14 @@
+@REM Set up environment so that we can run Visual Studio.
+@REM More-or-less the same effect as running vcvars32.bat
+@REM from the Visual Studio source tree.
+@REM @call vcvars32
+@set "PATH=C:\Program Files\Microsoft Visual Studio 10.0\VSTSDB\Deploy;C:\Program Files\Microsoft Visual Studio 10.0\Common7\IDE\;C:\Program Files\Microsoft Visual Studio 10.0\VC\BIN;C:\Program Files\Microsoft Visual Studio 10.0\Common7\Tools;C:\Windows\Microsoft.NET\Framework\v4.0.30319;C:\Windows\Microsoft.NET\Framework\v3.5;C:\Program Files\Microsoft Visual Studio 10.0\VC\VCPackages;C:\Program Files\HTML Help Workshop;C:\Program Files\Microsoft SDKs\Windows\7.0A\bin\NETFX 4.0 Tools;C:\Program Files\Microsoft SDKs\Windows\7.0A\bin;C:\Perl\site\bin;C:\Perl\bin;C:\windows\system32;C:\windows;C:\windows\system32\wbem"
+ 
+@REM Works around hangs when generating .pdb files
+@REM Needs to run in the background as never terminates
+@REM
+@start /min /b mspdbsrv -start -spawn -shutdowntime -1
+ 
+@msbuild livecode.sln /fl /nologo /p:Configuration=Release /m:1
+ 
+@exit


### PR DESCRIPTION
Use a hardcoded path for now. It assumes that all Windows
build tools are installed in default locations.
